### PR TITLE
Organization name should come first

### DIFF
--- a/octohat.cabal
+++ b/octohat.cabal
@@ -1,6 +1,6 @@
 Name:                octohat
-Version:             0.1
 Synopsis:            A tested, minimal wrapper around GitHub's API.
+Version:             0.1.1
 License:             MIT
 Author:              Stack Builders
 Maintainer:          hackage@stackbuilders.com

--- a/spec/Network/Octohat/MembersSpec.hs
+++ b/spec/Network/Octohat/MembersSpec.hs
@@ -48,7 +48,7 @@ spec = after removeTeams $ before setupToken $ do
     it "should get the public keys for a user" $ do
       -- This assumes the token belongs to testAccountOne
       Right testAccountOne <- runGitHub loadTestAccountOne
-      newKey <- runGitHub $ addPublicKey publicKeyFixture publicKeyHostnameFixture
+      _ <- runGitHub $ addPublicKey publicKeyFixture publicKeyHostnameFixture
 
       Right pubKey <- runGitHub $ publicKeysForUser (memberLogin testAccountOne)
       fmap (publicKeyFingerprint . fingerprintFor) pubKey `shouldBe` [fingerprintFixture]

--- a/spec/Network/Octohat/TestData.hs
+++ b/spec/Network/Octohat/TestData.hs
@@ -50,7 +50,7 @@ loadTestOrganizationName :: IO T.Text
 loadTestOrganizationName = organization `fmap` loadEnv
 
 loadOwnerTeam :: GitHub Team
-loadOwnerTeam = liftIO (organization `fmap` loadEnv) >>= teamForTeamNameInOrg "Owners"
+loadOwnerTeam = liftIO (organization `fmap` loadEnv) >>= flip teamForTeamNameInOrg "Owners"
 
 loadTestAccountOne :: GitHub Member
 loadTestAccountOne = liftIO (accountOne `fmap` loadEnv) >>= userForUsername

--- a/src/Network/Octohat.hs
+++ b/src/Network/Octohat.hs
@@ -38,10 +38,10 @@ keysOfTeamInOrganization nameOfOrg nameOfTeam = do
   let memberFingerprints = publicKeySetToFingerprints pubKeys
   return $ makeMembersWithKey members pubKeys memberFingerprints
 
-teamForTeamNameInOrg :: T.Text -- ^ Team name
-                     -> T.Text -- ^ Organization name
+teamForTeamNameInOrg :: T.Text -- ^ Organization name
+                     -> T.Text -- ^ Team name
                      -> GitHub Team
-teamForTeamNameInOrg nameOfTeam nameOfOrg = do
+teamForTeamNameInOrg nameOfOrg nameOfTeam = do
   teams <- teamsForOrganization nameOfOrg
   tryHead NotFound (teamsWithName nameOfTeam teams)
 


### PR DESCRIPTION
I have come at this issue several times now. I always mix up the orgName and the teamName.