### PR TITLE
Team Permissions, Repo types, organizations

### DIFF
--- a/.github-sandbox
+++ b/.github-sandbox
@@ -3,3 +3,4 @@ TEST_ACCOUNT_ONE=jsantos-testaccount2
 TEST_ACCOUNT_TWO=octohat-test-1
 TEST_ACCOUNT_THREE=octohat-test-2
 TEST_ACCOUNT_FOUR=octohat-test-3
+TEST_REPO=octohat-test-repo

--- a/octohat.cabal
+++ b/octohat.cabal
@@ -53,7 +53,7 @@ test-suite spec
   hs-source-dirs  :   spec
   main-is         :   Spec.hs
   build-depends   :   base               >= 4.5 && <4.8
-                    , base-compat        == 0.5.*
+                    , base-compat        == 0.6.*
                     , hspec              == 2.1.*
                     , hspec-expectations == 0.6.*
                     , text               == 1.2.*

--- a/octohat.cabal
+++ b/octohat.cabal
@@ -28,7 +28,7 @@ Library
     , errors               == 1.4.*
     , http-client          == 0.4.*
     , http-types           == 0.8.*
-    , lens                 >= 4.0 && <= 4.7
+    , lens                 >= 4.0 && <= 4.7.*
     , mtl                  == 2.*
     , text                 == 1.2.*
     , time                 == 1.4.*

--- a/octohat.cabal
+++ b/octohat.cabal
@@ -28,7 +28,7 @@ Library
     , errors               == 1.4.*
     , http-client          == 0.4.*
     , http-types           == 0.8.*
-    , lens                 >= 4.0 && <= 4.7.*
+    , lens                 >= 4.0 && <= 4.7.0.1
     , mtl                  == 2.*
     , text                 == 1.2.*
     , time                 == 1.4.*

--- a/octohat.cabal
+++ b/octohat.cabal
@@ -17,7 +17,7 @@ Library
   Build-depends:
       aeson                == 0.8.*
     , base                 >= 4.5 && < 4.8
-    , base-compat          == 0.5.*
+    , base-compat          == 0.6.*
     , base16-bytestring    == 0.1.1.*
     , base64-bytestring    == 1.0.*
     , bytestring           >= 0.9

--- a/spec/Network/Octohat/MembersSpec.hs
+++ b/spec/Network/Octohat/MembersSpec.hs
@@ -27,7 +27,7 @@ spec = after removeTeams $ before setupToken $ do
       testOrganization <- OrganizationName `fmap` loadTestOrganizationName
       Right ownerTeam  <- runGitHub loadOwnerTeam
 
-      Right newTeam           <- runGitHub $ addTeamToOrganization (TeamName "A new team") "A description" testOrganization
+      Right newTeam           <- runGitHub $ addTeamToOrganization (TeamName "A new team") "A description" PullAccess testOrganization
       Right teamsInOctohat    <- runGitHub $ teamsForOrganization testOrganization
       teamsInOctohat `shouldBe` [ownerTeam, newTeam]
       Right deleteResult      <- runGitHub $ deleteTeamFromOrganization (teamId newTeam)
@@ -39,7 +39,7 @@ spec = after removeTeams $ before setupToken $ do
       testOrganization     <- OrganizationName `fmap` loadTestOrganizationName
       Right testAccountOne <- runGitHub loadTestAccountOne
 
-      Right newTeam <- runGitHub $ addTeamToOrganization (TeamName "A new team") "A description" testOrganization
+      Right newTeam <- runGitHub $ addTeamToOrganization (TeamName "A new team") "A description" AdminAccess testOrganization
       let idForThisTeam = teamId newTeam
       Right addingStatus <- runGitHub $ addMemberToTeam (memberLogin testAccountOne) idForThisTeam
       addingStatus `shouldBe` Active
@@ -58,7 +58,7 @@ spec = after removeTeams $ before setupToken $ do
       testOrganization     <- OrganizationName `fmap` loadTestOrganizationName
       Right testAccount <- runGitHub loadTestAccountTwo
 
-      Right newTeam    <- runGitHub $ addTeamToOrganization (TeamName "Testing team") "Desc" testOrganization
+      Right newTeam    <- runGitHub $ addTeamToOrganization (TeamName "Testing team") "Desc" PushAccess testOrganization
       Right addStatus  <- runGitHub $ addMemberToTeam (memberLogin testAccount) (teamId newTeam)
       addStatus `shouldBe` Active
 

--- a/spec/Network/Octohat/TestData.hs
+++ b/spec/Network/Octohat/TestData.hs
@@ -71,10 +71,10 @@ publicKeyHostnameFixture :: T.Text
 publicKeyHostnameFixture = "octohat@stackbuilders"
 
 fingerprintFixture :: T.Text
-fingerprintFixture = "42:59:20:02:6f:df:b4:4a:1c:0e:fd:1b:86:58:f6:06"
+fingerprintFixture = "7c:11:af:a0:b7:ad:e4:76:d8:e0:d0:86:e0:7f:2a:fa"
 
 publicKeyFixture :: T.Text
-publicKeyFixture = "AAAAB3NzaC1yc2EAAAADAQABAAABAQC1Dopc3yxLWlzJwFqSoj0nAzRCU93R5DwNlogtRr/7NsnUVf443wl/vpRDRNscR0dV/VeNWYCqiZA0wGrXiVJ7HYi9XaWtHrUutLqrLe47aFFvAIdp15+RHkM0sXr963Kb9XMkmqswyXJ2TaZ0cgZfMNgl1ND248Y8fMDBx8elHwdZvyG2onG5aSVtOuKB4dWnmIb+uSQCN1K2kLYwHvQOjmqCiZ2XOP9u+ScphVdp6x4uAczH67CCRSUhI6U2fxSNf6YaDXyCWcqxj1agHUKdskb5rzxPaz5XZ2BgQscjoVo93M338HLmkyvbuP4yl2X6ZdLfE5mk2ZFfWQogxLGd"
+publicKeyFixture = "AAAAB3NzaC1yc2EAAAADAQABAAABAQCerupTuHE7jYE32vV9iKCwSLW44xkUprczufOLjlXVFWHe82CRPQyczBqJYHDk2AFNYGBQILTcPWLEDaPROqGMZBhdO684HBleTIWz9QrwEgLNNsXtQ8LGknyAWx7rJzBRQGh4Qxwxpbs0x0W/CqWun5x9XSO/mxTT5I2uZrp4D11aoV+bCEpe/Em4LdqTHaDXPN48oJz0sbmx4/dK19lowTMDrS/4zUTQKbdNaZpdJPYpPNt8vnf0MYiABqCSVynL70g2NM7suzO99DwwiDPmoYsIDpkPxt6xARdX1bJX0iNfv0n+BNuUZ/81ysvBj7IiZ+/bz49NOXRmKp+UbDh1"
 
 fullPublicKeyFixture :: T.Text
 fullPublicKeyFixture = T.concat ["ssh-rsa ", publicKeyFixture, " ", publicKeyHostnameFixture]

--- a/spec/Network/Octohat/TestData.hs
+++ b/spec/Network/Octohat/TestData.hs
@@ -6,6 +6,7 @@ module Network.Octohat.TestData ( loadTestOrganizationName
                                 , loadTestAccountTwo
                                 , loadTestAccountThree
                                 , loadTestAccountFour
+                                , loadTestRepo
                                 , publicKeyFixture
                                 , publicKeyHostnameFixture
                                 , fingerprintFixture
@@ -14,7 +15,7 @@ module Network.Octohat.TestData ( loadTestOrganizationName
 
 import Network.Octohat.Types
 import Network.Octohat (teamForTeamNameInOrg)
-import Network.Octohat.Members (userForUsername)
+import Network.Octohat.Members (userForUsername, repoForReponame)
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Arrow (second)
@@ -29,7 +30,8 @@ data TestEnvironment =
     accountOne   :: T.Text,
     accountTwo   :: T.Text,
     accountThree :: T.Text,
-    accountFour  :: T.Text
+    accountFour  :: T.Text,
+    testRepo     :: T.Text
   }
 
 readEnv :: [(String, String)] -> Maybe TestEnvironment
@@ -39,6 +41,7 @@ readEnv environment =
                   <*> lookup "TEST_ACCOUNT_TWO" env
                   <*> lookup "TEST_ACCOUNT_THREE" env
                   <*> lookup "TEST_ACCOUNT_FOUR" env
+                  <*> lookup "TEST_REPO" env
     where env = map (second T.pack) environment
 
 loadEnv :: IO TestEnvironment
@@ -66,6 +69,12 @@ loadTestAccountThree = liftIO (accountThree `fmap` loadEnv) >>= userForUsername
 
 loadTestAccountFour :: GitHub Member
 loadTestAccountFour = liftIO (accountFour `fmap` loadEnv) >>= userForUsername
+
+loadTestRepo :: GitHub Repo
+loadTestRepo = do 
+    org  <- liftIO (organization `fmap` loadEnv)
+    repo <- liftIO (testRepo `fmap` loadEnv)
+    repoForReponame org repo
 
 publicKeyHostnameFixture :: T.Text
 publicKeyHostnameFixture = "octohat@stackbuilders"

--- a/spec/Network/Octohat/TestData.hs
+++ b/spec/Network/Octohat/TestData.hs
@@ -80,10 +80,10 @@ publicKeyHostnameFixture :: T.Text
 publicKeyHostnameFixture = "octohat@stackbuilders"
 
 fingerprintFixture :: T.Text
-fingerprintFixture = "7c:11:af:a0:b7:ad:e4:76:d8:e0:d0:86:e0:7f:2a:fa"
+fingerprintFixture = "42:59:20:02:6f:df:b4:4a:1c:0e:fd:1b:86:58:f6:06"
 
 publicKeyFixture :: T.Text
-publicKeyFixture = "AAAAB3NzaC1yc2EAAAADAQABAAABAQCerupTuHE7jYE32vV9iKCwSLW44xkUprczufOLjlXVFWHe82CRPQyczBqJYHDk2AFNYGBQILTcPWLEDaPROqGMZBhdO684HBleTIWz9QrwEgLNNsXtQ8LGknyAWx7rJzBRQGh4Qxwxpbs0x0W/CqWun5x9XSO/mxTT5I2uZrp4D11aoV+bCEpe/Em4LdqTHaDXPN48oJz0sbmx4/dK19lowTMDrS/4zUTQKbdNaZpdJPYpPNt8vnf0MYiABqCSVynL70g2NM7suzO99DwwiDPmoYsIDpkPxt6xARdX1bJX0iNfv0n+BNuUZ/81ysvBj7IiZ+/bz49NOXRmKp+UbDh1"
+publicKeyFixture = "AAAAB3NzaC1yc2EAAAADAQABAAABAQC1Dopc3yxLWlzJwFqSoj0nAzRCU93R5DwNlogtRr/7NsnUVf443wl/vpRDRNscR0dV/VeNWYCqiZA0wGrXiVJ7HYi9XaWtHrUutLqrLe47aFFvAIdp15+RHkM0sXr963Kb9XMkmqswyXJ2TaZ0cgZfMNgl1ND248Y8fMDBx8elHwdZvyG2onG5aSVtOuKB4dWnmIb+uSQCN1K2kLYwHvQOjmqCiZ2XOP9u+ScphVdp6x4uAczH67CCRSUhI6U2fxSNf6YaDXyCWcqxj1agHUKdskb5rzxPaz5XZ2BgQscjoVo93M338HLmkyvbuP4yl2X6ZdLfE5mk2ZFfWQogxLGd"
 
 fullPublicKeyFixture :: T.Text
 fullPublicKeyFixture = T.concat ["ssh-rsa ", publicKeyFixture, " ", publicKeyHostnameFixture]

--- a/src/Network/Octohat/Members.hs
+++ b/src/Network/Octohat/Members.hs
@@ -4,14 +4,18 @@
 
 module Network.Octohat.Members
   ( membersForOrganization
-  , membersForTeam
   , teamsForOrganization
+  , membersForTeam
+  , reposForTeam
   , addMemberToTeam
+  , addRepoToTeam
   , deleteMemberFromTeam
   , deleteTeamFromOrganization
   , publicKeysForUser
   , addTeamToOrganization
+  , organizations
   , userForUsername
+  , repoForReponame 
   , addPublicKey
   ) where
 
@@ -28,8 +32,8 @@ addTeamToOrganization :: TeamName -- ^ Name of new team
                       -> TeamPermission -- ^ Permission setting for team (push, pull, or admin)
                       -> OrganizationName -- ^ Organization name where the team will be created
                       -> GitHub Team
-addTeamToOrganization (TeamName nameOfNewTeam) descOfTeam teamPerm (OrganizationName orgName) =
-  postRequestTo (composeEndpoint ["orgs", orgName, "teams"]) (TeamCreateRequest nameOfNewTeam descOfTeam teamPerm)
+addTeamToOrganization (TeamName nameOfNewTeam) descOfTeam teamPerm (OrganizationName org) =
+  postRequestTo (composeEndpoint ["orgs", org, "teams"]) (TeamCreateRequest nameOfNewTeam descOfTeam teamPerm)
 
 -- | Deletes a team from an organization using its team ID.
 deleteTeamFromOrganization :: Integer          -- ^ ID of Team to delete
@@ -46,10 +50,19 @@ membersForTeam :: Integer         -- ^ The team ID
                -> GitHub [Member]
 membersForTeam idOfTeam = getRequestTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "members"])
 
+-- | Returns a list of repos of a team with the given team ID.
+reposForTeam :: Integer         -- ^ The team ID
+              -> GitHub [Repo]
+reposForTeam idOfTeam = getRequestTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "repos"])
+
 -- | Returns a list of teams for the organization with the given name
 teamsForOrganization :: OrganizationName -- ^ The organization name
                      -> GitHub [Team]
 teamsForOrganization (OrganizationName nameOfOrg) = getRequestTo (composeEndpoint ["orgs", nameOfOrg, "teams"])
+
+-- | Returns a list of all organizations for the user
+organizations :: GitHub [Organization]
+organizations = getRequestTo (composeEndpoint ["user", "orgs"])
 
 -- | Adds a member to a team, might invite or add the member. Refer to 'StatusInTeam'
 addMemberToTeam :: T.Text               -- ^ The GitHub username to add to a team
@@ -57,6 +70,14 @@ addMemberToTeam :: T.Text               -- ^ The GitHub username to add to a tea
                 -> GitHub StatusInTeam
 addMemberToTeam nameOfUser idOfTeam =
   putRequestTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "memberships", nameOfUser])
+
+-- | Adds a repo to a team, might invite or add the member. Refer to 'StatusInTeam'
+addRepoToTeam :: OrganizationName     -- ^ The GitHub organization name 
+              -> T.Text               -- ^ The GitHub repo name
+              -> Integer              -- ^ The Team ID
+              -> GitHub StatusInTeam
+addRepoToTeam (OrganizationName nameOfOrg) nameOfRepo idOfTeam =
+  putRequestTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "repos", nameOfOrg, nameOfRepo])
 
 -- | Deletes a member with the given name from a team with the given ID. Might or might not delete
 deleteMemberFromTeam :: T.Text            -- ^ GitHub username
@@ -74,6 +95,12 @@ publicKeysForUser nameOfUser = getRequestTo (composeEndpoint ["users", nameOfUse
 userForUsername :: T.Text        -- ^ GitHub username
                 -> GitHub Member
 userForUsername username = getRequestTo (composeEndpoint ["users", username])
+
+-- | Finds a repo ID given their reponame
+repoForReponame :: T.Text        -- ^ GitHub org
+                -> T.Text        -- ^ GitHub repo
+                -> GitHub Repo
+repoForReponame org repo = getRequestTo (composeEndpoint ["repos", org, repo])
 
 -- | Add a key for the currently authenticated user
 addPublicKey :: T.Text -- ^ Base64 RSA Key (ssh-rsa AA..)

--- a/src/Network/Octohat/Members.hs
+++ b/src/Network/Octohat/Members.hs
@@ -25,10 +25,11 @@ import Data.Monoid ((<>))
 --   and creates a new team. Regular GitHub authorization/authentication applies.
 addTeamToOrganization :: TeamName -- ^ Name of new team
                       -> T.Text  -- ^ Description of new team
+                      -> TeamPermission -- ^ Permission setting for team (push, pull, or admin)
                       -> OrganizationName -- ^ Organization name where the team will be created
                       -> GitHub Team
-addTeamToOrganization (TeamName nameOfNewTeam) descOfTeam (OrganizationName orgName) =
-  postRequestTo (composeEndpoint ["orgs", orgName, "teams"]) (TeamCreateRequest nameOfNewTeam descOfTeam)
+addTeamToOrganization (TeamName nameOfNewTeam) descOfTeam teamPerm (OrganizationName orgName) =
+  postRequestTo (composeEndpoint ["orgs", orgName, "teams"]) (TeamCreateRequest nameOfNewTeam descOfTeam teamPerm)
 
 -- | Deletes a team from an organization using its team ID.
 deleteTeamFromOrganization :: Integer          -- ^ ID of Team to delete

--- a/src/Network/Octohat/Types.hs
+++ b/src/Network/Octohat/Types.hs
@@ -5,6 +5,8 @@ module Network.Octohat.Types ( Member(..)
                              , MemberWithKey(..)
                              , Team(..)
                              , TeamPermission(..)
+                             , Repo(..)
+                             , Organization(..)
                              , BearerToken(..)
                              , OrganizationName(..)
                              , TeamName(..)
@@ -48,6 +50,7 @@ data TeamPermission = OwnerAccess    -- ^ Default team of owners.
                                      --   repositories, as well as add other 
                                      --   collaborators to them. 
                     deriving (Show,Eq)
+
 -- | Represents a team in GitHub. Contains the team's ID, the team's name and an optional description
 data Team =
   Team { teamId          :: Integer
@@ -63,6 +66,20 @@ data TeamCreateRequest =
                     , newTeamDescription :: T.Text
                     , newTeamPermission  :: TeamPermission
                     } deriving (Show, Eq)
+
+-- | Represents an organisation in GitHub. Only has  name and description
+data Organization =
+  Organization 
+       { orgLogin       :: T.Text
+       , orgDescription :: Maybe T.Text
+       } deriving (Show, Eq)
+
+-- | Represents a repo in GitHub. Contains the Name, Description, and Private status
+data Repo =
+  Repo { repoName        :: T.Text
+       , repoDescription :: Maybe T.Text
+       , repoPrivate     :: Bool
+       } deriving (Show, Eq)
 
 -- | Represents a GitHub user with its public keys and fingerprints. A GitHub user might or might not
 --   have any public keys
@@ -141,6 +158,8 @@ instance ToJSON TeamPermission where
 
 $(deriveJSON defaultOptions { fieldLabelModifier = drop 6  . map toLower } ''Member)
 $(deriveJSON defaultOptions { fieldLabelModifier = drop 4  . map toLower } ''Team)
+$(deriveJSON defaultOptions { fieldLabelModifier = drop 4  . map toLower } ''Repo)
+$(deriveJSON defaultOptions { fieldLabelModifier = drop 3  . map toLower } ''Organization)
 $(deriveJSON defaultOptions { fieldLabelModifier = drop 7  . map toLower } ''TeamCreateRequest)
 $(deriveJSON defaultOptions { fieldLabelModifier = drop 19 . map toLower } ''AddPublicKeyRequest)
 

--- a/src/Network/Octohat/Types.hs
+++ b/src/Network/Octohat/Types.hs
@@ -4,6 +4,7 @@
 module Network.Octohat.Types ( Member(..)
                              , MemberWithKey(..)
                              , Team(..)
+                             , TeamPermission(..)
                              , BearerToken(..)
                              , OrganizationName(..)
                              , TeamName(..)
@@ -37,11 +38,22 @@ data Member =
          , memberId    :: Integer
          } deriving (Show, Eq)
 
+-- | Represents the different permissions that a team can have in an organisation.
+data TeamPermission = OwnerAccess    -- ^ Default team of owners.
+                    | PullAccess     -- ^ This team will be able to view and clone its
+                                     --   repositories.
+                    | PushAccess     -- ^ This team will be able to read its 
+                                     --   repositories, as well as push to them.
+                    | AdminAccess    -- ^ This team will be able to push/pull to its
+                                     --   repositories, as well as add other 
+                                     --   collaborators to them. 
+                    deriving (Show,Eq)
 -- | Represents a team in GitHub. Contains the team's ID, the team's name and an optional description
 data Team =
   Team { teamId          :: Integer
        , teamName        :: T.Text
        , teamDescription :: Maybe T.Text
+       , teamPermission  :: TeamPermission
        } deriving (Show, Eq)
 
 -- | Represents a request to create a new team within an organization. The rest of the paramaters
@@ -49,6 +61,7 @@ data Team =
 data TeamCreateRequest =
   TeamCreateRequest { newTeamName        :: T.Text
                     , newTeamDescription :: T.Text
+                    , newTeamPermission  :: TeamPermission
                     } deriving (Show, Eq)
 
 -- | Represents a GitHub user with its public keys and fingerprints. A GitHub user might or might not
@@ -106,6 +119,25 @@ instance FromJSON StatusInTeam where
       Just _         -> fail "\"state\" key not \"active\" or \"pending\""
       Nothing        -> (fail . maybe "No error message from GitHub" show) (HS.lookup "message" o)
   parseJSON _         = fail "Expected a membership document, got something else"
+
+instance FromJSON TeamPermission where
+  parseJSON (String p) = 
+    case p of
+      "pull"         -> pure PullAccess
+      "push"         -> pure PushAccess
+      "admin"        -> pure AdminAccess
+      "owner"        -> pure OwnerAccess
+      _              -> fail "Expected a valid team permission ?"
+  parseJSON _         = fail "Expected a team permssion, got something else"
+
+instance ToJSON TeamPermission where
+  toJSON p = 
+    case p of 
+      PullAccess   -> String "pull"
+      PushAccess   -> String "push"
+      AdminAccess  -> String "admin"
+      OwnerAccess  -> String "owner"
+
 
 $(deriveJSON defaultOptions { fieldLabelModifier = drop 6  . map toLower } ''Member)
 $(deriveJSON defaultOptions { fieldLabelModifier = drop 4  . map toLower } ''Team)


### PR DESCRIPTION
Hi Stakebuilders

The pull request may not be suitable as-is, but it has made it possible for me to proceed with my project. The key functionality required is:

  * access to the team permission information
  * access to GitHub repository objects
  * listing all the organizations

The patch also changes some of the cabal bounds so that it builds against the LTS Haskell 2.1. I don't think they will be serious.

There are tests for the new functions, and a new "TEST_REPO" to allow testing.

I am interested in continuing to use the library, and expanding it as I require. Let me know if you think I can help / coordinate with you guys.


Finlay