### PR TITLE
Depend on octohat 0.1.3, not 0.1.2

### DIFF
--- a/octohat.cabal
+++ b/octohat.cabal
@@ -59,7 +59,7 @@ Executable abc
     base                      >=4.4 && <4.8,
     text                      ==1.2.0.*,
     optparse-applicative      ==0.11.0.*,
-    octohat                   ==0.1.2,
+    octohat                   ==0.1.3,
     utf8-string               >=0.3 && <=1,
     yaml                      ==0.8.10.*
 


### PR DESCRIPTION
This fixes the broken travis build.