### PR TITLE
Add other-modules to export necessary dependencies

### DIFF
--- a/octohat.cabal
+++ b/octohat.cabal
@@ -1,7 +1,7 @@
 Name:                octohat
 Synopsis:            A tested, minimal wrapper around GitHub's API.
 Description:         A tested, minimal wrapper around GitHub's API.
-Version:             0.1.3
+Version:             0.1.4
 License:             MIT
 License-file:        LICENSE
 Author:              Stack Builders
@@ -59,11 +59,16 @@ Executable abc
     base                      >=4.4 && <4.8,
     text                      ==1.2.0.*,
     optparse-applicative      ==0.11.0.*,
-    octohat                   ==0.1.3,
+    octohat                   ==0.1.4,
     utf8-string               >=0.3 && <=1,
     yaml                      ==0.8.10.*
 
   default-language: Haskell2010
+
+  other-modules:   Web.GitHub.CLI.Actions
+                 , Web.GitHub.CLI.Messages
+                 , Web.GitHub.CLI.Options
+
   ghc-options: -threaded -Wall
 
 test-suite spec


### PR DESCRIPTION
This should fix the issues with openssh-github-keys. I'll merge when the tests pass.