### PR TITLE
Pagination support

### DIFF
--- a/src/Network/Octohat/Internal.hs
+++ b/src/Network/Octohat/Internal.hs
@@ -4,6 +4,7 @@
 module Network.Octohat.Internal
   ( putRequestTo
   , getRequestTo
+  , resetPage
   , getRequestPaginatedTo
   , postRequestTo
   , deleteRequestTo
@@ -54,6 +55,9 @@ getRequestTo uri = do
   response <- liftIO $ getWith opts (T.unpack uri)
   checkForStatus response
   tryRight $ getResponseEntity response
+
+resetPage :: GitHub ()
+resetPage = modify $ \pn -> pn { page = 1 }
 
 getRequestPaginatedTo :: (Monoid a, FromJSON a) => T.Text -> GitHub a
 getRequestPaginatedTo uri = do

--- a/src/Network/Octohat/Internal.hs
+++ b/src/Network/Octohat/Internal.hs
@@ -10,7 +10,7 @@ module Network.Octohat.Internal
   , composeEndpoint) where
 
 import Control.Error.Safe
-import Control.Lens (set, view, (^?))
+import Control.Lens (set, view, preview)
 import Control.Monad.Reader
 import Data.Monoid
 import Data.Aeson
@@ -61,7 +61,7 @@ getRequestPaginatedTo uri = do
         response <- liftIO $ getWith o (T.unpack u)
         checkForStatus response
         values <- tryRight $ getResponseEntity response
-        case response ^? responseLink "rel" "next" . linkURL of
+        case preview (responseLink "rel" "next" . linkURL) response  of
           Just next   -> combinedResponse o (decodeUtf8 next) $ acc <> values
           Nothing     -> return $ acc <> values
   combinedResponse opts uri mempty

--- a/src/Network/Octohat/Members.hs
+++ b/src/Network/Octohat/Members.hs
@@ -43,26 +43,26 @@ deleteTeamFromOrganization idOfTeam = deleteRequestTo (composeEndpoint ["teams",
 -- | Returns a list of members of an organization with the given name.
 membersForOrganization :: OrganizationName -- ^ The organization name
                        -> GitHub [Member]
-membersForOrganization (OrganizationName nameOfOrg) = getRequestTo (composeEndpoint ["orgs", nameOfOrg, "members"])
+membersForOrganization (OrganizationName nameOfOrg) = getRequestPaginatedTo (composeEndpoint ["orgs", nameOfOrg, "members"])
 
 -- | Returns a list of members of a team with the given team ID.
 membersForTeam :: Integer         -- ^ The team ID
                -> GitHub [Member]
-membersForTeam idOfTeam = getRequestTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "members"])
+membersForTeam idOfTeam = getRequestPaginatedTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "members"])
 
 -- | Returns a list of repos of a team with the given team ID.
 reposForTeam :: Integer         -- ^ The team ID
               -> GitHub [Repo]
-reposForTeam idOfTeam = getRequestTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "repos"])
+reposForTeam idOfTeam = getRequestPaginatedTo (composeEndpoint ["teams", T.pack $ show idOfTeam, "repos"])
 
 -- | Returns a list of teams for the organization with the given name
 teamsForOrganization :: OrganizationName -- ^ The organization name
                      -> GitHub [Team]
-teamsForOrganization (OrganizationName nameOfOrg) = getRequestTo (composeEndpoint ["orgs", nameOfOrg, "teams"])
+teamsForOrganization (OrganizationName nameOfOrg) = getRequestPaginatedTo (composeEndpoint ["orgs", nameOfOrg, "teams"])
 
 -- | Returns a list of all organizations for the user
 organizations :: GitHub [Organization]
-organizations = getRequestTo (composeEndpoint ["user", "orgs"])
+organizations = getRequestPaginatedTo (composeEndpoint ["user", "orgs"])
 
 -- | Adds a member to a team, might invite or add the member. Refer to 'StatusInTeam'
 addMemberToTeam :: T.Text               -- ^ The GitHub username to add to a team
@@ -89,7 +89,7 @@ deleteMemberFromTeam nameOfUser idOfTeam =
 -- | Returns the public keys of the user with the given name
 publicKeysForUser :: T.Text             -- ^ GitHub username
                   -> GitHub [PublicKey]
-publicKeysForUser nameOfUser = getRequestTo (composeEndpoint ["users", nameOfUser, "keys"])
+publicKeysForUser nameOfUser = getRequestPaginatedTo (composeEndpoint ["users", nameOfUser, "keys"])
 
 -- | Finds a user ID given their username
 userForUsername :: T.Text        -- ^ GitHub username

--- a/src/Network/Octohat/Members.hs
+++ b/src/Network/Octohat/Members.hs
@@ -17,6 +17,7 @@ module Network.Octohat.Members
   , userForUsername
   , repoForReponame 
   , addPublicKey
+  , resetPage
   ) where
 
 import Network.Octohat.Internal


### PR DESCRIPTION
Hi

This responds to Issue #29.

The main GitHub monad has a StateT added, that supports the Pagination state.

```haskell

data Links = Links { linkNext  :: Maybe Link, linkLast :: Maybe Link
                   , linkFirst :: Maybe Link, linkPrev :: Maybe Link } deriving Show

data Pagination = Pagination { perPage :: Int, page :: Int, links :: Links, recurse :: Bool } deriving Show

type GitHub = EitherT GitHubReturnStatus (ReaderT BearerToken (StateT Pagination IO))
``` 

Functions that return lists of things now use the following new function from Internal:
``` haskell
getRequestPaginatedTo :: (Monoid a, FromJSON a) => T.Text -> GitHub a
```

Apart from the obvious settings, the `recurse` state setting (default True) will force make the getRequestPaginatedTo function to  repeatedly call the GitHub API as long as there is a next Link.

The `resetPage` is a convenience to just reset the page to 1.

F


